### PR TITLE
Incorporate two websocket filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ ipch/
 *.VC.VC.opendb
 .vscode/*
 packages/*
+data/*

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ ipch/
 *.cachefile
 *.VC.db
 *.VC.VC.opendb
+.vscode/*
+packages/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8
 WORKDIR C:\\Palmtree
 COPY . .
 
-CMD ["msbuild", "-m", "AllProjects.sln", "/property:Configuration=Release"]
+CMD ["msbuild", "-m", "EmptyProject.sln", "/property:Configuration=Release"]
+# CMD ["msbuild", "-m", "AllProjects.sln", "/property:Configuration=Release"]

--- a/EmptyTask/EmptyTask.csproj
+++ b/EmptyTask/EmptyTask.csproj
@@ -92,6 +92,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="websocket-sharp, Version=1.0.1.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocketSharp-netstandard.1.0.1\lib\net45\websocket-sharp.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\EmptyTask.cs" />

--- a/EmptyTask/app.config
+++ b/EmptyTask/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <section name="Pipeline" type="Palmtree.Core.Helpers.AppConfig.PipelineConfigurationSection, Palmtree" requirePermission="false" />
@@ -15,15 +15,7 @@
 
   <Pipeline>
     <Filters>
-      <add name="WSIOFilter" type="WSIOFilter"/>
-      <add name="FeatureSelector" type="RedistributionFilter" />
-      <add name="TimeSmoothing" type="TimeSmoothingFilter"/>
-      <add name="Adaptation" type="AdaptationFilter"/>
-      <add name="LinearClassifier" type="RedistributionFilter"/>
-      <add name="KeySequence" type="KeySequenceFilter"/>
-      <add name="ThresholdClassifier" type="ThresholdClassifierFilter"/>
-      <add name="ClickTranslator" type="ClickTranslatorFilter"/>
-      <add name="Normalizer" type="NormalizerFilter"/>
+      <add name="WSIOFilter" type="WSIOFilter" />
       <!--<add name="Wasup" type="FlexKeySequenceFilter"/>-->
     </Filters>
   </Pipeline>

--- a/EmptyTask/packages.config
+++ b/EmptyTask/packages.config
@@ -8,4 +8,5 @@
   <package id="OpenTK.GLControl" version="3.1.0" targetFramework="net48" />
   <package id="SharpGL" version="2.4.0.0" targetFramework="net452" />
   <package id="SharpGL.WinForms" version="2.4.0.0" targetFramework="net452" />
+  <package id="WebSocketSharp-netstandard" version="1.0.1" targetFramework="net48" />
 </packages>

--- a/MoleTask/app.config
+++ b/MoleTask/app.config
@@ -15,6 +15,7 @@
 
   <Pipeline>
     <Filters>
+      <add name="WSIOFilter" type="WSIOFilter" />
       <add name="FeatureSelector" type="RedistributionFilter" />
       <add name="TimeSmoothing" type="TimeSmoothingFilter"/>
       <add name="Adaptation" type="AdaptationFilter"/>

--- a/MoleTask/app.config
+++ b/MoleTask/app.config
@@ -16,6 +16,7 @@
   <Pipeline>
     <Filters>
       <add name="WSIOFilter" type="WSIOFilter" />
+      <add name="WSIODataFilter" type="WSIODataFilter" />
       <add name="FeatureSelector" type="RedistributionFilter" />
       <add name="TimeSmoothing" type="TimeSmoothingFilter"/>
       <add name="Adaptation" type="AdaptationFilter"/>

--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -161,6 +161,7 @@
     <Compile Include="src\Core\Params\ParamSeperator.cs" />
     <Compile Include="src\Filters\RedistributionFilter.cs" />
     <Compile Include="src\Filters\FlexKeySequenceFilter.cs" />
+    <Compile Include="src\Filters\WSIO.cs" />
     <Compile Include="src\Filters\WSIOFilter.cs" />
     <Compile Include="src\Filters\WSIODataFilter.cs" />
     <Compile Include="src\GUI\GUIMore.cs">

--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -59,6 +59,9 @@
     <Reference Include="Expressive, Version=2.2.0.0, Culture=neutral, PublicKeyToken=96bf77aa50d0fd78, processorArchitecture=MSIL">
       <HintPath>..\packages\ExpressiveParser.2.2.0\lib\net45\Expressive.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.7.6\lib\net45\NLog.dll</HintPath>
     </Reference>
@@ -84,21 +87,48 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml" />
+    <Reference Include="websocket-sharp, Version=1.0.1.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocketSharp-netstandard.1.0.1\lib\net45\websocket-sharp.dll</HintPath>
+    </Reference>
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>dependencies\Windows.winmd</HintPath>

--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -59,6 +59,9 @@
     <Reference Include="Expressive, Version=2.2.0.0, Culture=neutral, PublicKeyToken=96bf77aa50d0fd78, processorArchitecture=MSIL">
       <HintPath>..\packages\ExpressiveParser.2.2.0\lib\net45\Expressive.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.7.6\lib\net45\NLog.dll</HintPath>
     </Reference>
@@ -84,21 +87,48 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml" />
+    <Reference Include="websocket-sharp, Version=1.0.1.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocketSharp-netstandard.1.0.1\lib\net45\websocket-sharp.dll</HintPath>
+    </Reference>
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>dependencies\Windows.winmd</HintPath>

--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -172,6 +172,7 @@
     <Compile Include="src\Core\Params\ParamIntArr.cs" />
     <Compile Include="src\Core\Params\ParamIntBase.cs" />
     <Compile Include="src\Core\Params\ParamIntMat.cs" />
+    <Compile Include="src\Core\Params\ParamSeperator.cs" />
     <Compile Include="src\Filters\AdaptationFilter.cs" />
     <Compile Include="src\Filters\ClickTranslatorFilter.cs" />
     <Compile Include="src\Filters\FilterBase.cs" />

--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -160,6 +160,7 @@
     <Compile Include="src\Filters\RedistributionFilter.cs" />
     <Compile Include="src\Filters\FlexKeySequenceFilter.cs" />
     <Compile Include="src\Filters\WSIOFilter.cs" />
+    <Compile Include="src\Filters\WSIODataFilter.cs" />
     <Compile Include="src\GUI\GUIMore.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -162,6 +162,7 @@
     <Compile Include="src\Filters\RedistributionFilter.cs" />
     <Compile Include="src\Filters\FlexKeySequenceFilter.cs" />
     <Compile Include="src\Filters\WSIOFilter.cs" />
+    <Compile Include="src\Filters\WSIODataFilter.cs" />
     <Compile Include="src\GUI\GUIMore.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Palmtree/packages.config
+++ b/Palmtree/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ExpressiveParser" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net48" />
   <package id="NLog" version="4.7.6" targetFramework="net48" />
   <package id="NLog.Config" version="4.7.6" targetFramework="net48" />
   <package id="NLog.Schema" version="4.7.6" targetFramework="net48" />
@@ -9,4 +10,13 @@
   <package id="OpenTK.GLControl" version="3.1.0" targetFramework="net48" />
   <package id="SharpGL" version="2.4.0.0" targetFramework="net452" />
   <package id="SharpGL.WinForms" version="2.4.0.0" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="5.0.1" targetFramework="net48" />
+  <package id="System.Text.Json" version="5.0.2" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="WebSocketSharp-netstandard" version="1.0.1" targetFramework="net48" />
 </packages>

--- a/Palmtree/src/Core/MainBoot.cs
+++ b/Palmtree/src/Core/MainBoot.cs
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The MainBoot class
  * 
  * ...
@@ -55,7 +55,8 @@ namespace Palmtree.Core {
                                                         new string[] { "ThresholdClassifierFilter", "Palmtree.Filters.ThresholdClassifierFilter" },
                                                         new string[] { "TimeSmoothingFilter",       "Palmtree.Filters.TimeSmoothingFilter"},
                                                         new string[] { "FlexKeySequenceFilter",     "Palmtree.Filters.FlexKeySequenceFilter" },
-                                                        new string[] { "WSIOFilter",                "Palmtree.Filters.WSIOFilter" }
+                                                        new string[] { "WSIOFilter",                "Palmtree.Filters.WSIOFilter" },
+                                                        new string[] { "WSIODataFilter",                "Palmtree.Filters.WSIODataFilter" }
                                                     };
 
         public static int getClassVersion() {

--- a/Palmtree/src/Filters/WSIO.cs
+++ b/Palmtree/src/Filters/WSIO.cs
@@ -1,0 +1,31 @@
+using NLog;
+using Palmtree.Core;
+using Palmtree.Core.DataIO;
+using Palmtree.Core.Params;
+using Palmtree.Filters;
+using System;
+using System.Linq;
+using WebSocketSharp;
+using WebSocketSharp.Server;
+using System.Text.Json;
+
+namespace Palmtree.Filters
+{
+
+    public class WSIO : WebSocketBehavior
+    {
+        private static NLog.Logger logger = LogManager.GetLogger("Data");
+
+        public class DataStruct
+        {
+            public string eventState { get; set; }
+            public string eventCode { get; set; }
+        }
+
+        protected override void OnMessage(MessageEventArgs e)
+        {
+            DataStruct dataStruct = JsonSerializer.Deserialize<DataStruct>(e.Data);
+            Data.logEvent(1, dataStruct.eventState, dataStruct.eventCode);
+        }
+    }
+}

--- a/Palmtree/src/Filters/WSIODataFilter.cs
+++ b/Palmtree/src/Filters/WSIODataFilter.cs
@@ -16,48 +16,13 @@ using NLog;
 using Palmtree.Core;
 using Palmtree.Core.DataIO;
 using Palmtree.Core.Params;
-
-using System;
-using System.Linq;
-using WebSocketSharp;
+using Palmtree.Filters;
 using WebSocketSharp.Server;
 
 
-// public class WSIO : WebSocketBehavior
-//     {
-//         private static NLog.Logger logger                            = LogManager.GetLogger("Data");
-
-//         public class DataStruct {
-//             public string eventState {get; set;}
-//             public string eventCode {get; set;}
-//         }
-
-//         protected override void OnMessage(MessageEventArgs e)
-//         {
-//             DataStruct dataStruct = JsonSerializer.Deserialize<DataStruct>(e.Data);
-//             Data.logEvent(1, dataStruct.eventState, dataStruct.eventCode);
-//             // Send("Received");
-//         }
-//     }
 namespace Palmtree.Filters
 {
-    public class WSIO : WebSocketBehavior
-    {
-        private static NLog.Logger logger = LogManager.GetLogger("Data");
 
-        public class DataStruct
-        {
-            public string eventState { get; set; }
-            public string eventCode { get; set; }
-        }
-
-        //protected override void OnMessage(MessageEventArgs e)
-        //{
-        //    //DataStruct dataStruct = JsonSerializer.Deserialize<DataStruct>(e.Data);
-        //    //Data.logEvent(1, dataStruct.eventState, dataStruct.eventCode);
-        //    Send("Received");
-        //}
-    }
     public class WSIODataFilter : FilterBase, IFilter
     {
         public static WebSocketServer wssv;
@@ -286,7 +251,7 @@ namespace Palmtree.Filters
 
         }
 
-        public void initialize()
+        public bool initialize()
         {
 
             // check if the filter is enabled
@@ -296,6 +261,7 @@ namespace Palmtree.Filters
                 wssv = new WebSocketServer("ws://localhost:" + wsPort);
                 wssv.AddWebSocketService<WSIO>("/");
             }
+            return true;
 
         }
 

--- a/Palmtree/src/Filters/WSIODataFilter.cs
+++ b/Palmtree/src/Filters/WSIODataFilter.cs
@@ -1,10 +1,10 @@
-/**
+﻿/**
  * WSIOFilter class
  * 
  * ...
  * 
  * 
- * Copyright (C) 2022:  Crone Lab, John Hopkins (Baltimore, USA) & external contributors
+ * Copyright (C) 2021:  Crone Lab, John Hopkins (Baltimore, USA) & external contributors
  * Author(s):           Christopher Coogan          (ccoogan2@jhmi.edu)
  * 
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software
@@ -14,6 +14,7 @@
  */
 using NLog;
 using Palmtree.Core;
+using Palmtree.Core.DataIO;
 using Palmtree.Core.Params;
 
 using System;
@@ -22,21 +23,48 @@ using WebSocketSharp;
 using WebSocketSharp.Server;
 
 
+// public class WSIO : WebSocketBehavior
+//     {
+//         private static NLog.Logger logger                            = LogManager.GetLogger("Data");
 
-namespace Palmtree.Filters {
-    public class WSIO2 : WebSocketBehavior
+//         public class DataStruct {
+//             public string eventState {get; set;}
+//             public string eventCode {get; set;}
+//         }
+
+//         protected override void OnMessage(MessageEventArgs e)
+//         {
+//             DataStruct dataStruct = JsonSerializer.Deserialize<DataStruct>(e.Data);
+//             Data.logEvent(1, dataStruct.eventState, dataStruct.eventCode);
+//             // Send("Received");
+//         }
+//     }
+namespace Palmtree.Filters
+{
+    public class WSIO : WebSocketBehavior
     {
-        protected override void OnMessage(MessageEventArgs e)
-        {
+        private static NLog.Logger logger = LogManager.GetLogger("Data");
 
-            Send("Received");
+        public class DataStruct
+        {
+            public string eventState { get; set; }
+            public string eventCode { get; set; }
         }
+
+        //protected override void OnMessage(MessageEventArgs e)
+        //{
+        //    //DataStruct dataStruct = JsonSerializer.Deserialize<DataStruct>(e.Data);
+        //    //Data.logEvent(1, dataStruct.eventState, dataStruct.eventCode);
+        //    Send("Received");
+        //}
     }
-    public class WSIOFilter : FilterBase, IFilter {
+    public class WSIODataFilter : FilterBase, IFilter
+    {
+        public static WebSocketServer wssv;
 
         private new const int CLASS_VERSION = 1;
-        WebSocketServer wssv;
-        public WSIOFilter(string filterName) {
+        public WSIODataFilter(string filterName)
+        {
             // set class version
             base.CLASS_VERSION = CLASS_VERSION;
 
@@ -48,7 +76,7 @@ namespace Palmtree.Filters {
             parameters = ParameterManager.GetParameters(filterName, Parameters.ParamSetTypes.Filter);
 
             // define the parameters
-            parameters.addParameter <bool>  (
+            parameters.addParameter<bool>(
                 "EnableFilter",
                 "Enable WSIO Filter",
                 "1");
@@ -58,13 +86,14 @@ namespace Palmtree.Filters {
                 "Log the filter's intermediate and output data streams. See 'Data' tab for more settings on sample stream logging.",
                 "0");
 
-            // message
-            logger.Info("Filter created (version " + CLASS_VERSION + ")");
-
             parameters.addParameter<double>(
                 "WebsocketPort",
                 "Port to send data out onto",
-                "21100");
+                "21122");
+
+
+            Data.eventLogged += Data_onEventLogged;
+
 
         }
 
@@ -73,17 +102,20 @@ namespace Palmtree.Filters {
          * parameters and, if valid, transfers the configuration parameters to local variables
          * (initialization of the filter is done later by the initialize function)
          **/
-        public bool configure(ref SamplePackageFormat input, out SamplePackageFormat output) {
+        public bool configure(ref SamplePackageFormat input, out SamplePackageFormat output)
+        {
 
             // check sample-major ordered input
-            if (input.valueOrder != SamplePackageFormat.ValueOrder.SampleMajor) {
+            if (input.valueOrder != SamplePackageFormat.ValueOrder.SampleMajor)
+            {
                 logger.Error("This filter is designed to work only with sample-major ordered input");
                 output = null;
                 return false;
             }
 
             // retrieve the number of input channels
-            if (input.numChannels <= 0) {
+            if (input.numChannels <= 0)
+            {
                 logger.Error("Number of input channels cannot be 0");
                 output = null;
                 return false;
@@ -95,9 +127,9 @@ namespace Palmtree.Filters {
             // store a references to the input and output format
             inputFormat = input;
             outputFormat = output;
-            
+
             // check the values and application logic of the parameters
-            if (!checkParameters(parameters))   return false;
+            if (!checkParameters(parameters)) return false;
 
             // transfer the parameters to local variables
             transferParameters(parameters);
@@ -113,14 +145,18 @@ namespace Palmtree.Filters {
 
         }
 
+
+
         /// <summary>Re-configure and/or reset the configration parameters of the filter (defined in the newParameters argument) on-the-fly.</summary>
         /// <param name="newParameters">Parameter object that defines the configuration parameters to be set. Set to NULL to leave the configuration parameters untouched.</param>
         /// <param name="resetOption">Filter reset options. 0 will reset the minimum; 1 will perform a complete reset of filter information. > 1 for custom resets.</param>
         /// <returns>A boolean, either true for a succesfull re-configuration, or false upon failure</returns>
-        public bool configureRunningFilter(Parameters newParameters, int resetOption) {
-            
+        public bool configureRunningFilter(Parameters newParameters, int resetOption)
+        {
+
             // check if new parameters are given (only a reset is also an option)
-            if (newParameters != null) {
+            if (newParameters != null)
+            {
 
                 //
                 // no pre-check on the number of output channels is needed here, the number of output
@@ -130,9 +166,14 @@ namespace Palmtree.Filters {
                 // check the values and application logic of the parameters
                 if (!checkParameters(newParameters)) return false;
 
+
+
+
+
                 // retrieve and check the LogDataStreams parameter
                 bool newLogDataStreams = newParameters.getValue<bool>("LogDataStreams");
-                if (!mLogDataStreams && newLogDataStreams) {
+                if (!mLogDataStreams && newLogDataStreams)
+                {
                     // logging was (in the initial configuration) switched off and is trying to be switched on
                     // (refuse, it cannot be switched on, because sample streams have to be registered during the first configuration)
 
@@ -148,7 +189,8 @@ namespace Palmtree.Filters {
                 transferParameters(newParameters);
 
                 // apply change in the logging of sample streams
-                if (mLogDataStreams && mLogDataStreamsRuntime && !newLogDataStreams) {
+                if (mLogDataStreams && mLogDataStreamsRuntime && !newLogDataStreams)
+                {
                     // logging was (in the initial configuration) switched on and is currently on but wants to be switched off (resulting in 0's being output)
 
                     // message
@@ -157,7 +199,9 @@ namespace Palmtree.Filters {
                     // switch logging off (to zeros)
                     mLogDataStreamsRuntime = false;
 
-                } else if (mLogDataStreams && !mLogDataStreamsRuntime && newLogDataStreams) {
+                }
+                else if (mLogDataStreams && !mLogDataStreamsRuntime && newLogDataStreams)
+                {
                     // logging was (in the initial configuration) switched on and is currently off but wants to be switched on (resume logging)
 
                     // message
@@ -189,7 +233,8 @@ namespace Palmtree.Filters {
         /**
          * check the values and application logic of the given parameter set
          **/
-        private bool checkParameters(Parameters newParameters) {
+        private bool checkParameters(Parameters newParameters)
+        {
 
 
             // TODO: parameters.checkminimum, checkmaximum
@@ -198,8 +243,9 @@ namespace Palmtree.Filters {
             bool newEnableFilter = newParameters.getValue<bool>("EnableFilter");
 
             // check if the filter is enabled
-            if (newEnableFilter) {
-                
+            if (newEnableFilter)
+            {
+
 
             }
 
@@ -211,97 +257,98 @@ namespace Palmtree.Filters {
         /**
          * transfer the given parameter set to local variables
          **/
-        private void transferParameters(Parameters newParameters) {
+        private void transferParameters(Parameters newParameters)
+        {
 
             // filter is enabled/disabled
             mEnableFilter = newParameters.getValue<bool>("EnableFilter");
 
             // check if the filter is enabled
-            if (mEnableFilter) {
-                
+            if (mEnableFilter)
+            {
+
             }
 
         }
 
-        private void printLocalConfiguration() {
+        private void printLocalConfiguration()
+        {
 
             // debug output
             logger.Debug("--- Filter configuration: " + filterName + " ---");
             logger.Debug("Input channels: " + inputFormat.numChannels);
             logger.Debug("Enabled: " + mEnableFilter);
             logger.Debug("Output channels: " + outputFormat.numChannels);
-            if (mEnableFilter) {
+            if (mEnableFilter)
+            {
 
             }
 
         }
 
-        public bool initialize() {
+        public void initialize()
+        {
 
             // check if the filter is enabled
-            if (mEnableFilter) {
+            if (mEnableFilter)
+            {
                 double wsPort = parameters.getValue<double>("WebsocketPort");
                 wssv = new WebSocketServer("ws://localhost:" + wsPort);
-                wssv.AddWebSocketService<WSIO2>("/");
+                wssv.AddWebSocketService<WSIO>("/");
             }
-            
-            // return success
-            return true;
 
         }
 
-        public void start() {
+        public void start()
+        {
             wssv.Start();
         }
 
-        public void stop() {
+        public void stop()
+        {
             wssv.Stop();
 
         }
 
-        public bool isStarted() {
+        public bool isStarted()
+        {
             return false;
         }
 
-        public void process(double[] input, out double[] output) {
-            
+        public void process(double[] input, out double[] output)
+        {
+
             // create the output package
             output = new double[input.Length];
-            
             // check if the filter is enabled
             output = input;
 
-            if (mEnableFilter) {
-                byte[] result = new byte[0];
-                output.Select(n => {
-                    BitConverter.GetBytes(n).ToArray().Select(m =>
-                    {
-                        result = result.Append(m).ToArray();
-                        
-                        return m;
-                    }).ToArray();
+            if (mEnableFilter)
+            {
 
-                    return n;
-                 }).ToArray();
-
-                result = result.Prepend(Convert.ToByte(outputFormat.packageRate)).ToArray();
-                result = result.Prepend(Convert.ToByte(outputFormat.numSamples)).ToArray();
-                result = result.Prepend(Convert.ToByte(outputFormat.numChannels)).ToArray();
-
-                if (wssv.IsListening)
-                {
-                    wssv.WebSocketServices["/"].Sessions.Broadcast(result);
-                }
             }
 
             // pass reference
 
             // handle the data logging of the output (both to file and for visualization)
             processOutputLogging(output);
-            
+
         }
-        
-        public void destroy() {
+
+        private void Data_onEventLogged(string message)
+        {
+            if (wssv.IsListening)
+            {
+
+                wssv.WebSocketServices["/"].Sessions.Broadcast(message);
+            }
+
+        }
+
+
+
+        public void destroy()
+        {
             wssv.Stop();
 
 

--- a/Palmtree/src/Filters/WSIOFilter.cs
+++ b/Palmtree/src/Filters/WSIOFilter.cs
@@ -15,21 +15,28 @@
 using NLog;
 using Palmtree.Core;
 using Palmtree.Core.Params;
+
 using System;
+using System.Linq;
+using WebSocketSharp;
+using WebSocketSharp.Server;
+
+
 
 namespace Palmtree.Filters {
+    public class WSIO : WebSocketBehavior
+    {
+        protected override void OnMessage(MessageEventArgs e)
+        {
 
-    /// <summary>
-    /// WSIOFilter class
-    /// 
-    /// ...
-    /// </summary>
+            Send("Received");
+        }
+    }
     public class WSIOFilter : FilterBase, IFilter {
 
         private new const int CLASS_VERSION = 1;
-        
+        WebSocketServer wssv;
         public WSIOFilter(string filterName) {
-
             // set class version
             base.CLASS_VERSION = CLASS_VERSION;
 
@@ -43,7 +50,7 @@ namespace Palmtree.Filters {
             // define the parameters
             parameters.addParameter <bool>  (
                 "EnableFilter",
-                "Enable TimeSmoothing Filter",
+                "Enable WSIO Filter",
                 "1");
 
             parameters.addParameter<bool>(
@@ -51,11 +58,16 @@ namespace Palmtree.Filters {
                 "Log the filter's intermediate and output data streams. See 'Data' tab for more settings on sample stream logging.",
                 "0");
 
-            // message
-            logger.Info("Filter created (version " + CLASS_VERSION + ")");
 
+            parameters.addParameter<double>(
+                "Websocket port",
+                "Port to send data out onto",
+                "23535");
+
+            wssv = new WebSocketServer("ws://localhost:21100");
+            wssv.AddWebSocketService<WSIO>("/");
         }
-        
+
         /**
          * Configure the filter. Checks the values and application logic of the
          * parameters and, if valid, transfers the configuration parameters to local variables
@@ -228,18 +240,15 @@ namespace Palmtree.Filters {
 
             // check if the filter is enabled
             if (mEnableFilter) {
-
-            
+                wssv.Start();
             }
 
         }
 
         public void start() {
-            
         }
 
         public void stop() {
-
         }
 
         public bool isStarted() {
@@ -250,18 +259,31 @@ namespace Palmtree.Filters {
             
             // create the output package
             output = new double[input.Length];
-            
             // check if the filter is enabled
-            if (mEnableFilter) {
-                // filter enabled
+            output = input;
 
-                // TODO: send input-package to anywhere...
-                
-    
+            if (mEnableFilter) {
+                byte[] result = new byte[0];
+                output.Select(n => {
+                    BitConverter.GetBytes(n).ToArray().Select(m =>
+                    {
+                        result = result.Append(m).ToArray();
+                        
+                        return m;
+                    }).ToArray();
+
+                    return n;
+                 }).ToArray();
+
+                result = result.Prepend(Convert.ToByte(outputFormat.packageRate)).ToArray();
+                result = result.Prepend(Convert.ToByte(outputFormat.numSamples)).ToArray();
+                result = result.Prepend(Convert.ToByte(outputFormat.numChannels)).ToArray();
+
+                wssv.WebSocketServices["/"].Sessions.Broadcast(result);
+
             }
 
             // pass reference
-            output = input;
 
             // handle the data logging of the output (both to file and for visualization)
             processOutputLogging(output);
@@ -269,6 +291,8 @@ namespace Palmtree.Filters {
         }
         
         public void destroy() {
+            wssv.Stop();
+
 
             // stop the filter
             // Note: At this point stop will probably have been called from the mainthread before destroy, however there is a slight

--- a/Palmtree/src/Filters/WSIOFilter.cs
+++ b/Palmtree/src/Filters/WSIOFilter.cs
@@ -23,20 +23,16 @@ using WebSocketSharp.Server;
 
 
 
-namespace Palmtree.Filters {
-    public class WSIO2 : WebSocketBehavior
-    {
-        protected override void OnMessage(MessageEventArgs e)
-        {
+namespace Palmtree.Filters
+{
 
-            Send("Received");
-        }
-    }
-    public class WSIOFilter : FilterBase, IFilter {
+    public class WSIOFilter : FilterBase, IFilter
+    {
 
         private new const int CLASS_VERSION = 1;
         WebSocketServer wssv;
-        public WSIOFilter(string filterName) {
+        public WSIOFilter(string filterName)
+        {
             // set class version
             base.CLASS_VERSION = CLASS_VERSION;
 
@@ -48,7 +44,7 @@ namespace Palmtree.Filters {
             parameters = ParameterManager.GetParameters(filterName, Parameters.ParamSetTypes.Filter);
 
             // define the parameters
-            parameters.addParameter <bool>  (
+            parameters.addParameter<bool>(
                 "EnableFilter",
                 "Enable WSIO Filter",
                 "1");
@@ -58,16 +54,13 @@ namespace Palmtree.Filters {
                 "Log the filter's intermediate and output data streams. See 'Data' tab for more settings on sample stream logging.",
                 "0");
 
-
             parameters.addParameter<double>(
                 "WebsocketPort",
                 "Port to send data out onto",
                 "21100");
 
-            parameters.addParameter<double>(
-                "WebsocketPort",
-                "Port to send data out onto",
-                "21100");
+
+
 
         }
 
@@ -76,17 +69,20 @@ namespace Palmtree.Filters {
          * parameters and, if valid, transfers the configuration parameters to local variables
          * (initialization of the filter is done later by the initialize function)
          **/
-        public bool configure(ref SamplePackageFormat input, out SamplePackageFormat output) {
+        public bool configure(ref SamplePackageFormat input, out SamplePackageFormat output)
+        {
 
             // check sample-major ordered input
-            if (input.valueOrder != SamplePackageFormat.ValueOrder.SampleMajor) {
+            if (input.valueOrder != SamplePackageFormat.ValueOrder.SampleMajor)
+            {
                 logger.Error("This filter is designed to work only with sample-major ordered input");
                 output = null;
                 return false;
             }
 
             // retrieve the number of input channels
-            if (input.numChannels <= 0) {
+            if (input.numChannels <= 0)
+            {
                 logger.Error("Number of input channels cannot be 0");
                 output = null;
                 return false;
@@ -98,9 +94,9 @@ namespace Palmtree.Filters {
             // store a references to the input and output format
             inputFormat = input;
             outputFormat = output;
-            
+
             // check the values and application logic of the parameters
-            if (!checkParameters(parameters))   return false;
+            if (!checkParameters(parameters)) return false;
 
             // transfer the parameters to local variables
             transferParameters(parameters);
@@ -116,14 +112,18 @@ namespace Palmtree.Filters {
 
         }
 
+
+
         /// <summary>Re-configure and/or reset the configration parameters of the filter (defined in the newParameters argument) on-the-fly.</summary>
         /// <param name="newParameters">Parameter object that defines the configuration parameters to be set. Set to NULL to leave the configuration parameters untouched.</param>
         /// <param name="resetOption">Filter reset options. 0 will reset the minimum; 1 will perform a complete reset of filter information. > 1 for custom resets.</param>
         /// <returns>A boolean, either true for a succesfull re-configuration, or false upon failure</returns>
-        public bool configureRunningFilter(Parameters newParameters, int resetOption) {
-            
+        public bool configureRunningFilter(Parameters newParameters, int resetOption)
+        {
+
             // check if new parameters are given (only a reset is also an option)
-            if (newParameters != null) {
+            if (newParameters != null)
+            {
 
                 //
                 // no pre-check on the number of output channels is needed here, the number of output
@@ -133,9 +133,14 @@ namespace Palmtree.Filters {
                 // check the values and application logic of the parameters
                 if (!checkParameters(newParameters)) return false;
 
+
+
+
+
                 // retrieve and check the LogDataStreams parameter
                 bool newLogDataStreams = newParameters.getValue<bool>("LogDataStreams");
-                if (!mLogDataStreams && newLogDataStreams) {
+                if (!mLogDataStreams && newLogDataStreams)
+                {
                     // logging was (in the initial configuration) switched off and is trying to be switched on
                     // (refuse, it cannot be switched on, because sample streams have to be registered during the first configuration)
 
@@ -151,7 +156,8 @@ namespace Palmtree.Filters {
                 transferParameters(newParameters);
 
                 // apply change in the logging of sample streams
-                if (mLogDataStreams && mLogDataStreamsRuntime && !newLogDataStreams) {
+                if (mLogDataStreams && mLogDataStreamsRuntime && !newLogDataStreams)
+                {
                     // logging was (in the initial configuration) switched on and is currently on but wants to be switched off (resulting in 0's being output)
 
                     // message
@@ -160,7 +166,9 @@ namespace Palmtree.Filters {
                     // switch logging off (to zeros)
                     mLogDataStreamsRuntime = false;
 
-                } else if (mLogDataStreams && !mLogDataStreamsRuntime && newLogDataStreams) {
+                }
+                else if (mLogDataStreams && !mLogDataStreamsRuntime && newLogDataStreams)
+                {
                     // logging was (in the initial configuration) switched on and is currently off but wants to be switched on (resume logging)
 
                     // message
@@ -192,7 +200,8 @@ namespace Palmtree.Filters {
         /**
          * check the values and application logic of the given parameter set
          **/
-        private bool checkParameters(Parameters newParameters) {
+        private bool checkParameters(Parameters newParameters)
+        {
 
 
             // TODO: parameters.checkminimum, checkmaximum
@@ -201,8 +210,9 @@ namespace Palmtree.Filters {
             bool newEnableFilter = newParameters.getValue<bool>("EnableFilter");
 
             // check if the filter is enabled
-            if (newEnableFilter) {
-                
+            if (newEnableFilter)
+            {
+
 
             }
 
@@ -214,77 +224,87 @@ namespace Palmtree.Filters {
         /**
          * transfer the given parameter set to local variables
          **/
-        private void transferParameters(Parameters newParameters) {
+        private void transferParameters(Parameters newParameters)
+        {
 
             // filter is enabled/disabled
             mEnableFilter = newParameters.getValue<bool>("EnableFilter");
 
             // check if the filter is enabled
-            if (mEnableFilter) {
-                
+            if (mEnableFilter)
+            {
+
             }
 
         }
 
-        private void printLocalConfiguration() {
+        private void printLocalConfiguration()
+        {
 
             // debug output
             logger.Debug("--- Filter configuration: " + filterName + " ---");
             logger.Debug("Input channels: " + inputFormat.numChannels);
             logger.Debug("Enabled: " + mEnableFilter);
             logger.Debug("Output channels: " + outputFormat.numChannels);
-            if (mEnableFilter) {
+            if (mEnableFilter)
+            {
 
             }
 
         }
 
-        public bool initialize() {
+        public bool initialize()
+        {
 
             // check if the filter is enabled
-            if (mEnableFilter) {
+            if (mEnableFilter)
+            {
                 double wsPort = parameters.getValue<double>("WebsocketPort");
                 wssv = new WebSocketServer("ws://localhost:" + wsPort);
-                wssv.AddWebSocketService<WSIO2>("/");
+                wssv.AddWebSocketService<WSIO>("/");
             }
-            
-            // return success
             return true;
 
         }
 
-        public void start() {
+        public void start()
+        {
             wssv.Start();
         }
 
-        public void stop() {
+        public void stop()
+        {
             wssv.Stop();
 
         }
 
-        public bool isStarted() {
+        public bool isStarted()
+        {
             return false;
         }
 
-        public void process(double[] input, out double[] output) {
-            
+        public void process(double[] input, out double[] output)
+        {
+
             // create the output package
             output = new double[input.Length];
             // check if the filter is enabled
             output = input;
 
-            if (mEnableFilter) {
+            if (mEnableFilter)
+            {
                 byte[] result = new byte[0];
-                output.Select(n => {
+                output.Select(n =>
+                {
                     BitConverter.GetBytes(n).ToArray().Select(m =>
                     {
                         result = result.Append(m).ToArray();
-                        
+
                         return m;
                     }).ToArray();
 
                     return n;
-                 }).ToArray();
+                }).ToArray();
 
                 result = result.Prepend(Convert.ToByte(outputFormat.packageRate)).ToArray();
                 result = result.Prepend(Convert.ToByte(outputFormat.numSamples)).ToArray();
@@ -300,10 +320,11 @@ namespace Palmtree.Filters {
 
             // handle the data logging of the output (both to file and for visualization)
             processOutputLogging(output);
-            
+
         }
-        
-        public void destroy() {
+
+        public void destroy()
+        {
             wssv.Stop();
 
 


### PR DESCRIPTION
One websocket filter (that runs on port 21122) streams the events when triggered. The other filter (port 21100) streams the byte stream of raw data. [palmtree.js](https://github.com/cronelab/palmtree.js) can parse the byte stream and display the raw samples.
@MaxvandenBoom , I could use your help in WSIO.cs to write the data that is received from the websocket client into the data log. This would allow 3rd party (web) applications to match the behavior you have in other tasks (the ability to write events like "RowClicked" with a timestamp).