### PR TITLE
Combined WSIOFilter (data and event servers)

### DIFF
--- a/Palmtree/Palmtree.csproj
+++ b/Palmtree/Palmtree.csproj
@@ -99,6 +99,15 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="websocket-sharp, Version=1.0.1.0, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocketSharp-netstandard.1.0.1\lib\net45\websocket-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Windows, Version=255.255.255.255, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>dependencies\Windows.winmd</HintPath>
@@ -131,6 +140,7 @@
     <Compile Include="src\Core\Params\ParamSeperator.cs" />
     <Compile Include="src\Filters\RedistributionFilter.cs" />
     <Compile Include="src\Filters\FlexKeySequenceFilter.cs" />
+    <Compile Include="src\Filters\WSIO.cs" />
     <Compile Include="src\Filters\WSIOFilter.cs" />
     <Compile Include="src\GUI\GUIMore.cs">
       <SubType>Form</SubType>

--- a/Palmtree/packages.config
+++ b/Palmtree/packages.config
@@ -9,4 +9,7 @@
   <package id="OpenTK.GLControl" version="3.1.0" targetFramework="net48" />
   <package id="SharpGL" version="2.4.0.0" targetFramework="net452" />
   <package id="SharpGL.WinForms" version="2.4.0.0" targetFramework="net452" />
+  <package id="WebSocketSharp-netstandard" version="1.0.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Text.Json" version="5.0.2" targetFramework="net48" />
 </packages>

--- a/Palmtree/src/Core/DataIO/Data.cs
+++ b/Palmtree/src/Core/DataIO/Data.cs
@@ -34,6 +34,8 @@ namespace Palmtree.Core.DataIO {
     ///       providing slightly better performance (important since the Data class is called upon very frequently)
     /// </summary>
     public static class Data {
+        public delegate void OnEventLogged(string eventMessage);
+        public static event OnEventLogged eventLogged;
 
         private const string CLASS_NAME                         = "Data";
         private const int CLASS_VERSION                         = 3;
@@ -1442,7 +1444,9 @@ namespace Palmtree.Core.DataIO {
 
                     // construct event String    
                     string eventOut = eventTime.ToString("yyyyMMdd_HHmmss_fff") + " " + eventRunElapsedTime + " " + strsourceSamplePackageCounter + " " + strDataSampleCounter + " " + text + " " + value;
-
+                    if(eventLogged != null) {
+                        eventLogged(eventOut);
+                    }
                     // write event to event file
                     if (eventStreamWriters.Count > levelIndex && eventStreamWriters[levelIndex] != null) {
 

--- a/Palmtree/src/Filters/WSIO.cs
+++ b/Palmtree/src/Filters/WSIO.cs
@@ -1,0 +1,31 @@
+using NLog;
+using Palmtree.Core;
+using Palmtree.Core.DataIO;
+using Palmtree.Core.Params;
+using Palmtree.Filters;
+using System;
+using System.Linq;
+using WebSocketSharp;
+using WebSocketSharp.Server;
+using System.Text.Json;
+
+namespace Palmtree.Filters
+{
+
+    public class WSIO : WebSocketBehavior
+    {
+        private static NLog.Logger logger = LogManager.GetLogger("Data");
+
+        public class DataStruct
+        {
+            public string eventState { get; set; }
+            public string eventCode { get; set; }
+        }
+
+        protected override void OnMessage(MessageEventArgs e)
+        {
+            DataStruct dataStruct = JsonSerializer.Deserialize<DataStruct>(e.Data);
+            Data.logEvent(1, dataStruct.eventState, dataStruct.eventCode);
+        }
+    }
+}


### PR DESCRIPTION
Okay, here's a cleaner changelog so we can sync up better. I combined the two WSIO*Filters into one, which hosts two different websocket servers (One to send 'event' information, and one to send 'data' information). The changes to Data.cs are simply adding a callback function OnEventLogged, which 'eventOut' gets passed to. This is so that WSIOFiltercs can utilized 'Data_onEventLogged' to send that event info to to event websocket server.

What I need help with from you is in the WSIO.cs class I have the OnMessage callback (inherited from WebsocketBehavior), which will allow the client to send a message back to the websocket server (wssv_events/data). We need a way of taking that packet and writing it to the Palmtree event log, allowing bidirectional communication with 3rd party apps. 

Let me know if this helps!